### PR TITLE
Enhance the commit message

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -7,7 +7,6 @@
 REGEX_ISSUE_ID="[a-zA-Z0-9,\.\_\-]+-[0-9]+"
 
 NC='\033[0m'
-BBlue='\033[1;34m'
 BRed='\033[1;31m'
 
 # Find current branch name
@@ -16,10 +15,14 @@ BRANCH_NAME=$(git symbolic-ref --short HEAD)
 # Extract issue id from branch name
 ISSUE_ID=$(echo "$BRANCH_NAME" | grep -o -E "$REGEX_ISSUE_ID")
 
-if [ -z "$ISSUE_ID" ]; then
-    echo -e "${BRed}Branch doesn't have Jira task code on itq... ${NC}"
-    echo -e "${BBlue}You can use ${BRed}git commit -m \"\" --no-verify${BBlue} to avoid this hook.${NC}"
-    exit 1
+# Extract commit message
+COMMIT_MESSAGE=$(cat "$1")
+
+# Exit and continue when the branch name doesn't have a JIRA issue key
+if [ -z $ISSUE_ID ]; then
+    echo -e "⚠️  ${BRed}The Branch doesn't have Jira task code on it... ${NC} \n"
+
+    exit 0
 fi
 
-echo "$ISSUE_ID"': '$(cat "$1") > "$1"
+echo "$ISSUE_ID: $COMMIT_MESSAGE" > $1

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -25,4 +25,10 @@ if [ -z $ISSUE_ID ]; then
     exit 0
 fi
 
+# Prevent adding a JIRA issue key in commits that already have a JIRA issue key
+# i.g. RA-1: RA-1: my feature
+if [[ $COMMIT_MESSAGE == $ISSUE_ID* ]]; then
+    exit 0
+fi
+
 echo "$ISSUE_ID: $COMMIT_MESSAGE" > $1


### PR DESCRIPTION
Prevent duplicated Jira issue keys on commits messages

Commits
![Screen Shot 2022-04-13 at 8 56 18 PM](https://user-images.githubusercontent.com/38913462/163289526-0b2d3c4a-50c8-4eb0-bec8-135411a11e06.png)
![Screen Shot 2022-04-13 at 9 12 17 PM](https://user-images.githubusercontent.com/38913462/163289621-5d1d589e-5f92-4686-a633-24e3cacf918f.png)

Result
![Screen Shot 2022-04-13 at 8 56 40 PM](https://user-images.githubusercontent.com/38913462/163289572-0041afda-98dd-4f4e-85eb-94176e4bf446.png)


-------------------------------

Add a warning and makes a commit without using the `--no-verify`
![Screen Shot 2022-04-13 at 8 54 21 PM](https://user-images.githubusercontent.com/38913462/163289661-8da93485-418b-4f73-b349-666151b30fef.png)

