### PR TITLE
fix  syntax error

### DIFF
--- a/run
+++ b/run
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Colors
 NC='\033[0m'


### PR DESCRIPTION
fix issue:

When trying to execute in popOs/ubuntu, we receive the following error:

```
/hooks.sh: 8: Syntax error: "(" unexpected
```
Using the bash instead of sh, solves the problem in ubuntu.